### PR TITLE
add gh actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,50 @@
+name: Publish JupyterBook to GitHub Pages
+
+on: 
+  push: # trigger build only when push to master
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7 
+    - name: Install Python dependencies
+      run: |
+        sudo apt-get install python3-pip
+        pip install jupyter-book
+        PATH="${PATH}:${HOME}/.local/bin"
+
+    - name: Create book template and build page HTML 
+      run: |
+        jupyter-book create mybook --content-folder content/
+        jupyter-book build ./mybook
+
+    - name: Install Ruby dependencies and make site
+      run: |
+        cd mybook
+        sudo gem install bundler:1.17.2 # for version see BUNDLED WITH in Gemfile.lock
+        bundle install
+        make site
+
+    - name: Push _site to gh-pages
+      run: |
+        sudo chown -R $(whoami):$(whoami) .
+        git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+        git config --global user.name "$GITHUB_ACTOR"
+        cd mybook 
+        cp -r _site /tmp
+        rm -rf *
+        mv /tmp/_site/* .
+        git checkout -b gh-pages
+        git add --all --force
+        git commit -a --allow-empty-message -m ''
+        git remote set-url origin "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY"
+        git push --force origin gh-pages 
+

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ for automatically deploying a Jupyter Book as a part of CI/CD.
 
 Currently, this repository has configurations for:
 
-|  Service | Configuration File                             | URL                                                    |
-|:--------:|------------------------------------------------|--------------------------------------------------------|
-| Netlify  | [`netlify.toml` ](netlify.toml )               | https://jupyter-book-deploy-demo.netlify.com           |
-| CircleCI | [`.circleci/config.yml`](.circleci/config.yml) | https://predictablynoisy.com/jupyter-book-deploy-demo/ |
-|          |                                                |                                                        |
+|  Service        | Configuration File                                         | URL                                                    |
+|:---------------:|------------------------------------------------------------|--------------------------------------------------------|
+| Netlify         | [`netlify.toml` ](netlify.toml )                           | https://jupyter-book-deploy-demo.netlify.com           |
+| CircleCI        | [`.circleci/config.yml`](.circleci/config.yml)             | https://predictablynoisy.com/jupyter-book-deploy-demo/ |
+| GitHub Actions  | [`.github/workflows/main.yml`](.github/workflows/main.yml) | http://username.github.io/jupyter-book-deploy-demo/    |
+|                 |                                                            |                                                        |


### PR DESCRIPTION
## Description 

This PR uses Github Actions to 

- Install dependencies for jupyter book

This is done in the steps: `name: Set up Python`, `name: Install Python dependencies` and `name: Install Ruby dependencies`

- Build a jupyter book and the site

In steps: `name: Create book template and build page HTML` and `make site`

- Publish the jupyter book on gh-pages

In the step: `name: Push _site to gh-pages`. 

See the published jupyter book by enabling GitHub Pages in the repository Settings and by choosing the source to be `gh-pages`.

The jupyter book is then available at https://username.github.io/jupyter-book-deploy-demo/ (ie, https://atrisovic.github.io/jupyter-book-deploy-demo/)